### PR TITLE
Add non-default export of Bitrix function 

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Init client with Bitrix API endpoint and access token and use the client to ease
 
 ```typescript
 import Bitrix from '@2bad/bitrix'
+// or for ESM
+import { Bitrix } from '@2bad/bitrix'
 
 const bitrix = Bitrix('https://PORTAL_NAME.bitrix24.ru/rest', 'ACCESS_TOKEN')
 

--- a/source/bitrix.ts
+++ b/source/bitrix.ts
@@ -15,7 +15,7 @@ import UsersService from './services/users'
  * @param clientOptions an object that will overwrite underlying configuration for HTTP client,
  *                see `https://github.com/sindresorhus/got/blob/main/documentation/2-options.md`.
  */
-export default (restURI: string, accessToken?: string, clientOptions?: ExtendOptions) => {
+export const Bitrix = (restURI: string, accessToken?: string, clientOptions?: ExtendOptions) => {
   const { call, batch, list } = Client(restURI, accessToken, clientOptions)
 
   return {
@@ -30,6 +30,8 @@ export default (restURI: string, accessToken?: string, clientOptions?: ExtendOpt
     users: UsersService({ call })
   }
 }
+
+export default Bitrix
 
 export * from './methods'
 export * from './commands'


### PR DESCRIPTION
Hi, after migration to ESM, default export no more works for me. It doesn't see that `Bitrix` is a function.