### PR TITLE
publish to npm via trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,5 +24,3 @@ jobs:
 
       - run: npm ci
       - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
npm tokens are being restricted (account changes Aug 2026, direct publishing Jan 2027) and the existing ones are expiring. Publishing already goes through OIDC when a trusted publisher is configured, so the token env var is a dead fallback path.

Needs a trusted publisher on npmjs.com for this package before the next release: repository 2BAD/bitrix, workflow publish.yml, no environment.